### PR TITLE
#38 binary tree 생성 시 괄호 leak 해결

### DIFF
--- a/ds_tree/delete.c
+++ b/ds_tree/delete.c
@@ -6,7 +6,7 @@
 /*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/08 23:33:50 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/11 18:22:27 by jeongmin         ###   ########.fr       */
+/*   Updated: 2023/01/12 14:29:37 by jeongmin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,6 +30,8 @@ void	del_node(t_tnode *node, void (*del)(void *))
 {
 	t_pos	pos;
 
+	if (!node)
+		return ;
 	if (node->left || node->right)
 	{
 		printf("del_node error: node has child.");

--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@
 /*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/08 22:30:32 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/11 23:01:54 by jeongmin         ###   ########.fr       */
+/*   Updated: 2023/01/12 16:33:30 by jeongmin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,21 @@
 #include "builtin.h"
 #include "make_tree.h"
 #include "minishell.h"
+
+static void	del_t_paren(void *content)
+{
+	t_token	*token;
+
+	if (!content)
+		return ;
+	token = (t_token *)(content);
+	if (!is_this_symbol(token, T_PAREN))
+		return ;
+	if (token->str)
+		free(token->str);
+	free(content);
+	content = NULL;
+}
 
 void	print_lst(t_list *lst)
 {
@@ -60,8 +75,8 @@ int	main(int argc, char **argv, char **env)
 		print_lst(lst->next);
 		node = make_tree(lst->next);
 		preorder(node, 0, "root");
-		clear_node(node, NULL);
-		ft_lstclear(&lst, del_t_token);
+		ft_lstclear(&lst, del_t_paren);
+		clear_node(node, del_t_token);
 		free(str);
 	}
 	return (0);

--- a/parsing/check.c
+++ b/parsing/check.c
@@ -6,7 +6,7 @@
 /*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/11 17:38:04 by jeongmin          #+#    #+#             */
-/*   Updated: 2023/01/11 23:12:53 by jeongmin         ###   ########.fr       */
+/*   Updated: 2023/01/12 15:12:23 by jeongmin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,7 +41,7 @@ t_list	*check_end_node(t_list **lst)
 		end = end->next;
 	if (!(end->next))
 		return (NULL);
-	if (end == *lst)
+	if (is_this_symbol(end->content, T_PAREN))
 	{
 		*lst = (*lst)->next;
 		return (NULL);

--- a/parsing/check.c
+++ b/parsing/check.c
@@ -6,7 +6,7 @@
 /*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/11 17:38:04 by jeongmin          #+#    #+#             */
-/*   Updated: 2023/01/12 15:12:23 by jeongmin         ###   ########.fr       */
+/*   Updated: 2023/01/12 16:30:21 by jeongmin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,7 +43,7 @@ t_list	*check_end_node(t_list **lst)
 		return (NULL);
 	if (is_this_symbol(end->content, T_PAREN))
 	{
-		*lst = (*lst)->next;
+		*lst = end;
 		return (NULL);
 	}
 	return (end);

--- a/parsing/token.c
+++ b/parsing/token.c
@@ -6,7 +6,7 @@
 /*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/10 16:15:15 by jeongmin          #+#    #+#             */
-/*   Updated: 2023/01/11 17:05:51 by jeongmin         ###   ########.fr       */
+/*   Updated: 2023/01/12 15:19:09 by jeongmin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,7 @@ void	del_t_token(void *content)
 	if (token->str)
 		free(token->str);
 	free(content);
+	content = NULL;
 }
 
 static t_error	make_token(char *line, t_ttype type, size_t len, t_list **lst)


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

linked-list 를 해제할 때 괄호 token도 같이 해제하는 `void	del_t_paren(void *content)` 를 만들었어요.

## 🧑‍💻 PR 세부 내용

https://github.com/mingxoxo/minishell/pull/39 에서 tree를 해제할 때 `content`(token)을 함께 해제하지 않고, 
linked-list를 해제할 때는 `content`(token)를 해제하도록 해두어서 leak 검사에 메모리 누수가 잡히지 않았어요.

이후 linked-list가 아닌 tree를 이후에 해제하도록 코드가 작성되어야 해요.
하지만 tree를 생성할 때 괄호(`T_PAREN`) token은 포함되지 않아요.
그래서  linked-list를 해제할 때 괄호 token일 경우는 `content`도 같이 해제하는 함수인 `del_t_paren(void *content)` 를 만들었어요.

현재는 함수가 `main` 파일에 들어있어 `static`으로 선언되어 있고, 이후 파싱 함수를 합칠 때 파일을 옮길 예정이에요.

추가적으로 괄호가 비어있을 때 `segfault`가 나지 않고 `NULL`로 반환되도록 작성했어요.
하지만 `segfault`가 나오는 경우의 수는 tree를 만들기 전에 check 되도록 기능을 추가해야 해요!

**주요 함수**
```c
static void	del_t_paren(void *content)
{
	t_token	*token;

	if (!content)
		return ;
	token = (t_token *)(content);
	if (!is_this_symbol(token, T_PAREN))
		return ;
	if (token->str)
		free(token->str);
	free(content);
	content = NULL;
}
```
