### PR TITLE
#42 트리 생성 시 괄호의 올바른 짝을 찾도록 bug 수정

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/09/28 21:52:18 by wonyang           #+#    #+#              #
-#    Updated: 2023/01/12 18:26:19 by jeongmin         ###   ########.fr        #
+#    Updated: 2023/01/12 19:43:29 by jeongmin         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -66,7 +66,8 @@ PARSING_DIR		= parsing/
 
 _PARSING_SRCS	= token.c \
 				  arr.c \
-				  check.c \
+				  check_tnode.c \
+				  check_type.c \
 				  make_node.c \
 				  make_tree.c
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/09/28 21:52:18 by wonyang           #+#    #+#              #
-#    Updated: 2023/01/11 19:17:33 by jeongmin         ###   ########.fr        #
+#    Updated: 2023/01/12 18:26:19 by jeongmin         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -24,7 +24,7 @@ HEADERS		= -I$(LIBFT) \
 LIBS		= -lft -L$(LIBFT) \
 			  -L$(RDLINE_DIR)/lib/ -lreadline\
 
-CFLAGS		= -Wall -Werror -Wextra
+CFLAGS		= -Wall -Werror -Wextra -g3 -fsanitize=address
 
 # builtin source files
 BTN_DIR		= builtin/

--- a/includes/make_tree.h
+++ b/includes/make_tree.h
@@ -6,7 +6,7 @@
 /*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/10 16:01:53 by jeongmin          #+#    #+#             */
-/*   Updated: 2023/01/11 23:11:13 by jeongmin         ###   ########.fr       */
+/*   Updated: 2023/01/12 19:45:11 by jeongmin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,9 @@
 # include <stdlib.h>
 # include <stdbool.h>
 
+# define OPEN_PAREN 1
+# define CLOSE_PAREN 2
+
 // make_tree.c
 t_tnode	*make_tree(t_list *head);
 
@@ -28,9 +31,12 @@ t_error	make_dsv_node(t_tnode **node, t_list *lst);
 t_error	make_t_io(t_tnode *node, t_list **lst);
 t_error	make_t_word(t_tnode *node, t_list *lst);
 
-// check.c
+// check_type.c
 bool	is_dsv_symbol(t_token *token);
 bool	is_this_symbol(t_token *token, t_ttype type);
+int		check_paren(t_token *token);
+
+// check_tnode.c
 t_list	*check_end_node(t_list **lst);
 t_tnode	*check_parent(t_tnode *node, t_token *token);
 t_tnode	*check_root(t_tnode *node);

--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@
 /*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/08 22:30:32 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/12 16:33:30 by jeongmin         ###   ########.fr       */
+/*   Updated: 2023/01/12 18:29:23 by jeongmin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,12 +38,14 @@ void	print_lst(t_list *lst)
 {
 	t_token	*token;
 
+	printf("---------\n");
 	while (lst)
 	{
 		token = (t_token *)(lst->content);
 		printf("[%d] [%s]\n", token->type, token->str);
 		lst = lst->next;
 	}
+	printf("---------\n");
 }
 
 int	main(int argc, char **argv, char **env)

--- a/parsing/check_tnode.c
+++ b/parsing/check_tnode.c
@@ -1,44 +1,33 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   check.c                                            :+:      :+:    :+:   */
+/*   check_tnode.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/11 17:38:04 by jeongmin          #+#    #+#             */
-/*   Updated: 2023/01/12 16:30:21 by jeongmin         ###   ########.fr       */
+/*   Updated: 2023/01/12 19:45:07 by jeongmin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "make_tree.h"
 
-bool	is_dsv_symbol(t_token *token)
-{
-	if (token == NULL)
-		return (false);
-	if (token->type == T_OPER || token->type == T_PIPE)
-		return (true);
-	return (false);
-}
-
-bool	is_this_symbol(t_token *token, t_ttype type)
-{
-	if (token == NULL)
-		return (false);
-	if (token->type == type)
-		return (true);
-	return (false);
-}
-
 t_list	*check_end_node(t_list **lst)
 {
+	int		cnt;
 	t_list	*end;
 
 	end = *lst;
 	if (!end)
 		return (NULL);
-	while (end->next && !is_this_symbol(end->next->content, T_PAREN))
+	cnt = 1;
+	while (end->next)
+	{
+		cnt += check_paren(end->next->content);
+		if (cnt == 0)
+			break ;
 		end = end->next;
+	}
 	if (!(end->next))
 		return (NULL);
 	if (is_this_symbol(end->content, T_PAREN))

--- a/parsing/check_type.c
+++ b/parsing/check_type.c
@@ -1,50 +1,45 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   syatax_error.c                                     :+:      :+:    :+:   */
+/*   check_type.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2023/01/12 17:45:48 by jeongmin          #+#    #+#             */
-/*   Updated: 2023/01/12 18:44:10 by jeongmin         ###   ########.fr       */
+/*   Created: 2023/01/11 17:38:04 by jeongmin          #+#    #+#             */
+/*   Updated: 2023/01/12 19:45:12 by jeongmin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "make_tree.h"
 
-int	chk_paren(t_token *token)
+bool	is_dsv_symbol(t_token *token)
+{
+	if (token == NULL)
+		return (false);
+	if (token->type == T_OPER || token->type == T_PIPE)
+		return (true);
+	return (false);
+}
+
+bool	is_this_symbol(t_token *token, t_ttype type)
+{
+	if (token == NULL)
+		return (false);
+	if (token->type == type)
+		return (true);
+	return (false);
+}
+
+int	check_paren(t_token *token)
 {
 	if (is_this_symbol(token, T_PAREN))
 	{
 		if (!token->str)
 			return (0);
 		if (ft_strcmp(token->str, "(") == 0)
-			return (1);
+			return (OPEN_PAREN);
 		else if (ft_strcmp(token->str, ")") == 0)
-			return (-1);
+			return (CLOSE_PAREN);
 	}
 	return (0);
-}
-
-static bool	is_correct_paren(t_list *lst)
-{
-	int	cnt;
-
-	cnt = 0;
-	while (lst)
-	{
-		cnt += chk_paren(lst->content);
-		if (cnt < 0)
-			return (false);
-	}
-	if (cnt != 0)
-		return (false);
-	return (true);
-}
-
-bool	is_correct_syntax(t_list *lst)
-{
-	if (!is_correct_paren)
-		return (false);
-	return (true);
 }

--- a/parsing/syatax_error.c
+++ b/parsing/syatax_error.c
@@ -1,0 +1,50 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   syatax_error.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/01/12 17:45:48 by jeongmin          #+#    #+#             */
+/*   Updated: 2023/01/12 18:44:10 by jeongmin         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "make_tree.h"
+
+int	chk_paren(t_token *token)
+{
+	if (is_this_symbol(token, T_PAREN))
+	{
+		if (!token->str)
+			return (0);
+		if (ft_strcmp(token->str, "(") == 0)
+			return (1);
+		else if (ft_strcmp(token->str, ")") == 0)
+			return (-1);
+	}
+	return (0);
+}
+
+static bool	is_correct_paren(t_list *lst)
+{
+	int	cnt;
+
+	cnt = 0;
+	while (lst)
+	{
+		cnt += chk_paren(lst->content);
+		if (cnt < 0)
+			return (false);
+	}
+	if (cnt != 0)
+		return (false);
+	return (true);
+}
+
+bool	is_correct_syntax(t_list *lst)
+{
+	if (!is_correct_paren)
+		return (false);
+	return (true);
+}


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

괄호의 올바른 짝을 찾을 수 있도록 수정했어요!

## 🧑‍💻 PR 세부 내용

`(((ls)))` 가 입력으로 들어갈 때 이전 코드에서는 무조건 맨 처음에 나오는 닫힌 괄호` )` 를 찾아서 새로운 리스트를 생성했어요.
따라서 `((ls` 가 담긴 연결리스트를 인자로 재귀가 돌고있었어요.

열린 괄호의 올바른 짝인 닫힌 괄호를 찾는 함수
`t_list *check_end_node(t_list **lst)`를 수정했어요.
- 괄호 사이의 개수를 세어서 올바른 짝을 찾는 방법

## 📸 스크린샷

<img width="150" alt="스크린샷 2023-01-12 오후 7 52 25" src="https://user-images.githubusercontent.com/44529556/212048059-71b7e5b8-82f7-4e43-8da1-8e0e2b5772b5.png">

## To-do
- `((( ls )))` 와 같이 의미 없는 괄호가 여러번 반복될 경우 bash에서는 syntax error
- 따라서 트리 만들기 이전에 확인이 필요