### PR TITLE
Refactor : #30/export - 함수 인자 변경

### DIFF
--- a/builtin/print_export.c
+++ b/builtin/print_export.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/09 20:04:00 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/13 22:12:25 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/14 17:06:19 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -94,14 +94,14 @@ static char	**make_arr(t_envp *envp)
 	return (key_arr);
 }
 
-t_error	print_envp(t_envp *envp)
+int	print_envp(t_envp *envp)
 {
 	int		i;
 	char	**key_arr;
 
 	key_arr = make_arr(envp);
 	if (!key_arr)
-		return (ERROR);
+		return (1);
 	i = 0;
 	while (key_arr[i])
 	{
@@ -109,5 +109,5 @@ t_error	print_envp(t_envp *envp)
 		i++;
 	}
 	free(key_arr);
-	return (SCS);
+	return (0);
 }

--- a/ds_envp/cast_list.c
+++ b/ds_envp/cast_list.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   cast_list.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
+/*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/08 16:21:17 by jeongmin          #+#    #+#             */
-/*   Updated: 2023/01/08 22:52:31 by jeongmin         ###   ########.fr       */
+/*   Updated: 2023/01/14 17:11:37 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,7 @@ static int	search_sep(char *line)
 	return (-1);
 }
 
-static t_error	get_key(char *line, char **key)
+t_error	get_key(char *line, char **key)
 {
 	int	sep;
 

--- a/execute/builtin.c
+++ b/execute/builtin.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/13 18:36:41 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/14 12:58:24 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/14 18:36:25 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,10 +23,10 @@ extern t_global	g_var;
 
 bool	is_builtin_cmd(t_tnode *node)
 {
-	t_token	*token;
+	t_token		*token;
 	const char	cmd[7][7] = {"echo", "pwd", "cd", "env", "export", \
 								"unset", "exit"};
-	int		i;
+	int			i;
 
 	if (!node || !node->content)
 	{

--- a/includes/ds_envp.h
+++ b/includes/ds_envp.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ds_envp.h                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
+/*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/07 17:17:28 by jeongmin          #+#    #+#             */
-/*   Updated: 2023/01/09 15:57:49 by jeongmin         ###   ########.fr       */
+/*   Updated: 2023/01/14 17:11:41 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,6 +52,7 @@ t_enode	*search_key_enode(t_envp *envp, char *key);
 char	*search_key_value(t_envp *envp, char *key);
 
 // cast_*.c
+t_error	get_key(char *line, char **key);
 char	**cast_envp_arr(t_envp *envp);
 t_error	cast_envp_line(t_envp *envp, char *line);
 t_error	cast_envp_list(t_envp *envp, char **arr);

--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/08 22:30:32 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/14 13:00:36 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/14 18:34:14 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -93,6 +93,7 @@ int	main(int argc, char **argv, char **env)
 		ft_lstclear(&lst, del_t_paren);
 		clear_node(node, del_t_token);
 		free(str);
+		// system("leaks minishell | grep leaks");
 	}
 	clear_envp(&(g_var.envp));
 	return (g_var.status);


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

ft_export의 함수 인자 처리 변경

## 🧑‍💻 PR 세부 내용

### ft_export 변경사항
- 환경변수 등록을 한번에 여러 개 할 수 있도록 변경 
   ex) `export a=hi b=hello c=wow`
- 키 유효성 검사 추가
    - 키가 빈문자열이거나 `'`, `"`, `공백`을 포함한 문자열일 경우 `not a valid identifier` 에러 출력
- 인자에 `=`이 없는 경우 key만 등록
    - 기존에 등록된 key가 없는 경우 value 없는 key만 등록
    - 기존에 등록된 key가 있는 경우 작업 무시
- key=value 형태 파싱 기능 추가 (set_export 함수)
    - `key=`만 들어온 경우 value는 빈문자열("")
### 기타 변경사항
- ds_envp/cast_list.c
    - export 함수에서 사용을 위해 get_key 함수를 static에서 public 함수로 변경

## 📸 스크린샷

<img width="476" alt="스크린샷 2023-01-14 오후 6 48 48" src="https://user-images.githubusercontent.com/43935708/212466120-933917cb-c8e7-4dc9-8d0a-dfbb06bf8bf3.png">
