### PR TITLE
Bug : #53/선언되지 않은 환경변수 에러

### DIFF
--- a/execute/child.c
+++ b/execute/child.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/11 23:33:05 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/14 21:21:41 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/14 22:34:33 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,9 +51,12 @@ static t_error	child_execute(t_tnode *cmd_node)
 		ft_freesplit(cmd_argv);
 		return (ERROR);
 	}
-	if (is_builtin_cmd(cmd_node) == false && !path)
+	if (ft_strcmp(cmd_argv[0], "") == 0
+		|| (is_builtin_cmd(cmd_node) == false && !path))
 	{
-		perror("command not found");
+		ft_putstr_fd("bash: ", STDERR_FILENO);
+		ft_putstr_fd(cmd_argv[0], STDERR_FILENO);
+		ft_putendl_fd(": command not found", STDERR_FILENO);
 		exit(127);
 	}
 	if (apply_redirections(cmd_node) == ERROR

--- a/execute/child.c
+++ b/execute/child.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/11 23:33:05 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/14 12:53:27 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/14 21:21:41 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,6 +34,7 @@ static t_error	child_execve(t_tnode *node, char *path, char **argv)
 	if (is_builtin_cmd(node) == true)
 		exit(builtin_execve(builtin, argv, &(g_var.envp), 1));
 	execve(path, argv, g_var.envp.arr);
+	exit(0);
 	return (ERROR);
 }
 

--- a/execute/path.c
+++ b/execute/path.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/11 17:19:11 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/13 15:22:10 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/14 22:33:47 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -88,7 +88,7 @@ t_error	make_cmd_path(char *cmd_name, char **path, char **envp)
 	*path = NULL;
 	if (access(cmd_name, X_OK) == 0)
 	{
-		*path = cmd_name;
+		*path = ft_strdup(cmd_name);
 		return (SCS);
 	}
 	path_list = parse_paths(envp);


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

선언되지 않은 환경변수가 들어왔을 때 발생하는 오류 수정

## 🧑‍💻 PR 세부 내용

### 원인
- 빈 문자열이 들어올 경우 실행파일 path를 `/bin/`와 같이 디렉토리를 가르키게 됨
- 여기서 execve 실행 시 permission denied가 뜸
- 자식 프로세스가 파이프를 닫지 못한 채 종료되어 프로그램이 정상종료 되지 않음

### 수정사항
- 빈 문자열이 들어온 경우 무조건 `command not found` 에러 출력
- 에러 문구 수정

## 📸 스크린샷

<img width="971" alt="스크린샷 2023-01-14 오후 10 38 47" src="https://user-images.githubusercontent.com/43935708/212474702-cdd1b728-3712-4435-9426-c865c7814def.png">
