### PR TITLE
Bug: #54/터미널 세팅 복구

### DIFF
--- a/main.c
+++ b/main.c
@@ -6,11 +6,12 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/08 22:30:32 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/14 18:34:14 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/14 22:47:58 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
+#include <unistd.h>
 #include <readline/readline.h>
 #include <readline/history.h>
 #include "libft.h"
@@ -90,6 +91,7 @@ int	main(int argc, char **argv, char **env)
 			execute_builtin(node);
 		else
 			execute_cmds(node);
+		tcsetattr(STDIN_FILENO, TCSANOW, &(g_var.new_term));
 		ft_lstclear(&lst, del_t_paren);
 		clear_node(node, del_t_token);
 		free(str);


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

명령어 실행 후 터미널 설정이 돌아오지 않는 오류를 수정

## 🧑‍💻 PR 세부 내용

### 원인 및 해결
- 명령어 실행 전 자식 프로세스에서 `미니쉘 시작시 바꾼 터미널 세팅`을 되돌림
- 자식 프로세스에서 바꾼 터미널 세팅도 부모 프로세스에서 영향이 있었음
- 명령어 실행 과정이 끝난 후 다시 터미널 세팅을 해줌

## 📸 스크린샷

<img width="513" alt="스크린샷 2023-01-14 오후 10 51 50" src="https://user-images.githubusercontent.com/43935708/212475322-d3f6c411-7a4f-4132-a88f-cf4a3de84644.png">
