### PR TITLE
Bug : #46/부모 프로세스 시그널 핸들링

### DIFF
--- a/execute/child.c
+++ b/execute/child.c
@@ -6,13 +6,14 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/11 23:33:05 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/14 22:34:33 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/15 11:46:51 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <signal.h>
 #include "minishell.h"
 #include "ds_envp.h"
 #include "execute.h"
@@ -123,6 +124,7 @@ t_error	create_childs(t_tnode **cmd_list, pid_t *pid_list)
 
 	before_fd = STDIN_FILENO;
 	i = 0;
+	signal(SIGINT, SIG_IGN);
 	while (cmd_list[i + 1])
 	{
 		pid_list[i] = fork_child(cmd_list[i], &before_fd);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/10 19:35:48 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/13 17:17:47 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/15 11:45:51 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,6 +25,7 @@ typedef struct s_global
 	int				status;
 }	t_global;
 
+void	set_signal_handling(void);
 void	set_minishell_setting(void);
 
 #endif

--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/08 22:30:32 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/14 22:47:58 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/15 11:46:01 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -92,6 +92,7 @@ int	main(int argc, char **argv, char **env)
 		else
 			execute_cmds(node);
 		tcsetattr(STDIN_FILENO, TCSANOW, &(g_var.new_term));
+		set_signal_handling();
 		ft_lstclear(&lst, del_t_paren);
 		clear_node(node, del_t_token);
 		free(str);

--- a/terminal.c
+++ b/terminal.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/10 15:47:32 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/13 17:17:56 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/15 11:49:27 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,13 +32,14 @@ static void	get_terminal_setting(void)
 static void	sigint_handler_prompt(int signo)
 {
 	(void)signo;
+	g_var.status = 1;
 	ft_putchar_fd('\n', STDOUT_FILENO);
 	rl_on_new_line();
 	rl_replace_line("", 0);
 	rl_redisplay();
 }
 
-static void	set_signal_handling(void)
+void	set_signal_handling(void)
 {
 	signal(SIGINT, sigint_handler_prompt);
 }


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

부모 프로세스의 시그널 핸들링 추가

## 🧑‍💻 PR 세부 내용

### 문제 원인분석
- #46 에서 발생하는 문제의 원인은 부모 프로세스의 SIGINT를 끄지 않았기 때문
- 기존에는 자식 프로세스가 실행되기 전 부모의 SIGINT 설정을 끄지 않음
- 이에 따라 명령어 실행 중 SIGINT 시그널을 보내면 부모, 자식 모두 시그널을 받게 됨
- 부모 프로세스의 SIGINT 설정에 따라 prompt가 한 번 더 출력 되었음

### 해결
- 자식 프로세스 실행 전 부모 프로세스가 SIGINT를 ignore 하도록 핸들링
- 명령어 실행 후 시그널 설정을 원래대로 되돌림

### 추가 수정사항
- bash에서 SIGINT를 받으면 마지막 종료상태가 1됨
- minishell의 SIGINT 설정에도 이를 추가

### 앞으로 해야할 일
- minishell의 터미널 설정과 시그널 설정 함수 정리
- main문 로직 분리 및 리팩토링

## 📸 스크린샷
<img width="180" alt="스크린샷 2023-01-15 오전 11 57 36" src="https://user-images.githubusercontent.com/43935708/212520575-af440be1-6671-4808-acd2-603d9c2b8886.png">
<img width="180" alt="스크린샷 2023-01-15 오전 11 57 06" src="https://user-images.githubusercontent.com/43935708/212520564-67eb99a2-2684-4604-9109-7b24ad1d3629.png">