### PR TITLE
Bug : #60/heredoc 오류 수정

### DIFF
--- a/builtin/env.c
+++ b/builtin/env.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/09 12:40:20 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/13 21:47:59 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/15 15:52:52 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,7 +31,7 @@ int	ft_env(char **argv, t_envp *envp)
 		ft_putstr_fd("env: ", STDERR_FILENO);
 		ft_putstr_fd(argv[1], STDERR_FILENO);
 		ft_putendl_fd(": No such file or directory", STDERR_FILENO);
-		return (1);
+		return (127);
 	}
 	arr = envp->arr;
 	i = 0;

--- a/execute/builtin.c
+++ b/execute/builtin.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/13 18:36:41 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/14 18:36:25 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/15 15:47:52 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,17 +70,23 @@ t_error	execute_builtin(t_tnode *node)
 {
 	char	**cmd_argv;
 	char	*path;
+	int		in_fd;
+	int		out_fd;
 
 	path = ((t_token *)(node->content))->str;
 	cmd_argv = make_argv(node);
 	if (!cmd_argv)
 		return (ERROR);
-	if (apply_redirections(node) == ERROR)
+	in_fd = dup(STDIN_FILENO);
+	out_fd = dup(STDOUT_FILENO);
+	if (in_fd < 0 || out_fd < 0 || apply_redirections(node) == ERROR)
 	{
 		ft_freesplit(cmd_argv);
 		return (ERROR);
 	}
 	g_var.status = builtin_execve(path, cmd_argv, &(g_var.envp), 0);
+	ft_dup2(in_fd, STDIN_FILENO);
+	ft_dup2(out_fd, STDOUT_FILENO);
 	ft_freesplit(cmd_argv);
 	return (SCS);
 }

--- a/execute/child.c
+++ b/execute/child.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/11 23:33:05 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/15 11:46:51 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/15 16:38:25 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -60,8 +60,7 @@ static t_error	child_execute(t_tnode *cmd_node)
 		ft_putendl_fd(": command not found", STDERR_FILENO);
 		exit(127);
 	}
-	if (apply_redirections(cmd_node) == ERROR
-		|| child_execve(cmd_node, path, cmd_argv) == ERROR)
+	if (child_execve(cmd_node, path, cmd_argv) == ERROR)
 	{
 		free(path);
 		ft_freesplit(cmd_argv);


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

리다이렉션과 heredoc 오류 수정

## 🧑‍💻 PR 세부 내용

### 문제사항 및 원인
- 부모 프로세스에서 실행되는 빌트인 함수의 리다이렉션 적용이 제대로 되지 않음
    - 부모 프로세스의 표준 입출력을 리다이렉션을 통해 변경 후 원상 복구 시켜놓지 않았음
- heredoc이 제대로 실행되지 않던 오류 #60 
    - apply_redirection 함수가 두번 적용되고 있었음

### 변경사항
- 부모 프로세스의 리다이렉션 변경 전 기존 표준 입출력 fd를 저장해두고 다시 복구
- apply_redirection 함수 수정
- ft_env의 argument 오류 반환값을 1에서 127으로 수정