### PR TITLE
Implement : #57/따옴표 제거

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+         #
+#    By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/09/28 21:52:18 by wonyang           #+#    #+#              #
-#    Updated: 2023/01/15 17:20:42 by wonyang          ###   ########seoul.kr   #
+#    Updated: 2023/01/15 19:03:14 by jeongmin         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -75,7 +75,8 @@ _PARSING_SRCS	= token.c \
 				  subst_env.c \
 				  subst_env_first.c \
 				  subst_env_lst.c \
-				  subst_env_second.c
+				  subst_env_second.c \
+				  del_quote.c
 
 PARSING_SRCS	= $(addprefix $(PARSING_DIR), $(_PARSING_SRCS))
 

--- a/includes/make_tree.h
+++ b/includes/make_tree.h
@@ -6,7 +6,7 @@
 /*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/10 16:01:53 by jeongmin          #+#    #+#             */
-/*   Updated: 2023/01/15 15:00:12 by jeongmin         ###   ########.fr       */
+/*   Updated: 2023/01/15 19:08:10 by jeongmin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,6 +54,8 @@ t_error	env_second_step(char *str, t_tnode *node);
 
 // subset_env_lst.c
 t_error	subst_env_lst(t_token *token, int *arr, t_list **head);
-char	*strjoin_lst(t_list *lst);
+
+// del_quote.c
+t_error	del_quote(t_tnode *node);
 
 #endif

--- a/includes/make_tree.h
+++ b/includes/make_tree.h
@@ -6,7 +6,7 @@
 /*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/10 16:01:53 by jeongmin          #+#    #+#             */
-/*   Updated: 2023/01/15 19:08:10 by jeongmin         ###   ########.fr       */
+/*   Updated: 2023/01/15 19:11:13 by jeongmin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,8 +51,6 @@ t_error	subst_env(t_tnode *node);
 // subst_env_*.c
 t_error	env_first_step(t_token *token);
 t_error	env_second_step(char *str, t_tnode *node);
-
-// subset_env_lst.c
 t_error	subst_env_lst(t_token *token, int *arr, t_list **head);
 
 // del_quote.c

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
+/*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/10 19:35:48 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/15 17:47:17 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/15 19:07:01 by jeongmin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,6 +19,7 @@
 # include "ds_tree.h"
 
 # define PROMPT "\033[0;36mCUTE-Shell$\033[0m "
+
 typedef struct s_global
 {
 	t_envp			envp;

--- a/parse.c
+++ b/parse.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parse.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
+/*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/15 17:20:31 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/15 17:47:28 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/15 18:35:24 by jeongmin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,7 +50,7 @@ t_tnode	*parse_line(char *str)
 	}
 	node = make_tree(lst->next);
 	ft_lstclear(&lst, del_t_paren);
-	if (subst_env(node) == ERROR || !node)
+	if (subst_env(node) == ERROR || del_quote(node) == ERROR || !node)
 	{
 		free(str);
 		return (NULL);

--- a/parsing/del_quote.c
+++ b/parsing/del_quote.c
@@ -1,0 +1,100 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   del_quote.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/01/15 18:13:30 by jeongmin          #+#    #+#             */
+/*   Updated: 2023/01/15 19:07:16 by jeongmin         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "make_tree.h"
+
+static void	del_quote_str(char *new, char *line, int *arr, size_t len)
+{
+	size_t	i;
+	size_t	cnt;
+
+	i = 0;
+	cnt = 0;
+	while (i < len)
+	{
+		if (arr[i] == T_QUOTE)
+		{
+			i++;
+			continue ;
+		}
+		ft_strlcat(new, line + i, cnt + 2);
+		cnt++;
+		i++;
+	}
+}
+
+static size_t	handling_del_quote(char *line, int *arr)
+{
+	size_t	len;
+	char	*start;
+	char	*end;
+
+	len = 0;
+	start = line;
+	while (*start)
+	{
+		if (*start == '\"' || *start == '\'')
+		{
+			end = ft_strchr(start + 1, *start);
+			if (!end)
+				arr[start - line] = T_WORD;
+			else
+			{
+				arr[start - line] = T_QUOTE;
+				arr[end - line] = T_QUOTE;
+				make_word_arr(arr, start - line + 1, end - line - 1);
+				start = end;
+				len += 2;
+			}
+		}
+		start++;
+	}
+	return (len);
+}
+
+static t_error	del_quote_token(t_token *token)
+{
+	size_t	len;
+	size_t	del;
+	int		*arr;
+	char	*new;
+
+	len = ft_strlen(token->str);
+	arr = init_arr(len);
+	if (!arr)
+		return (ERROR);
+	del = handling_del_quote(token->str, arr);
+	new = ft_calloc(len - del + 1, sizeof(char));
+	if (!new)
+	{
+		free(arr);
+		return (ERROR);
+	}
+	del_quote_str(new, token->str, arr, len);
+	free(token->str);
+	token->str = new;
+	free(arr);
+	return (SCS);
+}
+
+t_error	del_quote(t_tnode *node)
+{
+	t_error	errno;
+
+	if (!node)
+		return (SCS);
+	errno = del_quote(node->left);
+	errno = del_quote(node->right);
+	if (is_this_symbol(node->content, T_WORD))
+		return (del_quote_token(node->content));
+	return (errno);
+}

--- a/parsing/subst_env_lst.c
+++ b/parsing/subst_env_lst.c
@@ -6,7 +6,7 @@
 /*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/13 17:42:37 by jeongmin          #+#    #+#             */
-/*   Updated: 2023/01/15 15:20:12 by jeongmin         ###   ########.fr       */
+/*   Updated: 2023/01/15 19:08:06 by jeongmin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -79,7 +79,7 @@ static size_t	strlen_lst(t_list *lst)
 	return (len);
 }
 
-char	*strjoin_lst(t_list *lst)
+static char	*strjoin_lst(t_list *lst)
 {
 	size_t	len;
 	char	*new;


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

cmd, arg, 리다이렉션 file명에 달려있는 따옴표를 제거

## 🧑‍💻 PR 세부 내용

**따옴표 제거 대상**
- t_type이 `T_WORD`인 노드
   - cmd
   - arg
   - redirection file

- 따옴표의 짝은 앞에서부터 읽으면서 모양이 일치하는 것을 의미한다.
- 짝이 없는 따옴표는 문자로 판단하고 제거하지 않는다.

**구현 흐름**
1. node에 str에 대해서 지워야하는 따옴표를 arr 배열에 표시하면서 
지워야 하는 따옴표 개수를 count 한 후 반환
2. `strlen(str) - count + 1` 만큼 배열 할당(NULL 개수 포함)
3. 따옴표를 제외하고 `strlcat` 함수를 사용하여 문자 이어 붙이기

## 📸 스크린샷

<img width="208" alt="스크린샷 2023-01-15 오후 7 20 08" src="https://user-images.githubusercontent.com/44529556/212535244-2d0f994b-eb1e-4695-b95a-45e032aa4f90.png">
