### PR TITLE
Bug : #71/[fix] 환경변수 head 삭제 시 envp 연결 오류

### DIFF
--- a/ds_envp/delete.c
+++ b/ds_envp/delete.c
@@ -6,7 +6,7 @@
 /*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/07 17:17:28 by jeongmin          #+#    #+#             */
-/*   Updated: 2023/01/09 16:20:00 by jeongmin         ###   ########.fr       */
+/*   Updated: 2023/01/16 13:32:52 by jeongmin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,7 +47,7 @@ static void	del_enode(t_envp *envp, t_enode *node)
 		return ;
 	}
 	if (envp->head == node)
-		envp->head = NULL;
+		envp->head = node->next;
 	del_prev = node->prev;
 	del_next = node->next;
 	if (del_prev)


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

맨 앞 환경변수를 삭제할 때 그 환경변수가 들어있는 enode가 head일 때 처리 수정

## 🧑‍💻 PR 세부 내용

del_enode가 head일 때 처리

**[변경 전]**
```c
if (envp->head == node)
	envp->head = NULL;
```

**[변경 후]**
```c
if (envp->head == node)
	envp->head = node->next;
```

## 📸 스크린샷

<img width="1240" alt="스크린샷 2023-01-16 오후 1 42 46" src="https://user-images.githubusercontent.com/44529556/212600209-b7259e06-7dbc-4c42-9d3a-ae665cb8e750.png">
