### PR TITLE
Refactor : #70/heredoc - 시그널 처리

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+         #
+#    By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/09/28 21:52:18 by wonyang           #+#    #+#              #
-#    Updated: 2023/01/16 17:11:46 by jeongmin         ###   ########.fr        #
+#    Updated: 2023/01/16 17:40:57 by wonyang          ###   ########seoul.kr   #
 #                                                                              #
 # **************************************************************************** #
 
@@ -101,7 +101,8 @@ EXE_SRCS		= $(addprefix $(EXE_DIR), $(_EXE_SRCS))
 # main source files
 SRCS		= main.c \
 			  terminal.c \
-			  parse.c
+			  parse.c \
+			  signal.c
 
 OBJS		= $(BTN_SRCS:%.c=%.o) \
 			  $(TREE_SRCS:%.c=%.o) \

--- a/execute/execute.c
+++ b/execute/execute.c
@@ -6,17 +6,17 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/11 22:30:55 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/16 18:37:21 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/16 19:14:20 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdlib.h>
 #include <unistd.h>
+#include <sys/wait.h>
 #include "minishell.h"
 #include "execute.h"
 #include "libft.h"
 #include "make_tree.h"
-#include <sys/wait.h>
 
 extern t_global	g_var;
 

--- a/execute/execute.c
+++ b/execute/execute.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/11 22:30:55 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/16 12:21:11 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/16 18:37:21 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,7 +59,7 @@ static t_error	execute_child(t_tnode *root)
 		return (ERROR);
 	pid_list = empty_pid_list(cmd_list);
 	if (!pid_list
-		|| execute_all_heredoc(cmd_list) == ERROR
+		|| execute_all_heredoc(cmd_list) != SCS
 		|| create_childs(cmd_list, pid_list) == ERROR)
 	{
 		free(pid_list);

--- a/execute/heredoc.c
+++ b/execute/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/11 18:40:41 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/16 18:40:52 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/16 19:01:51 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,21 +36,16 @@ t_error	execute_all_heredoc(t_tnode **cmd_list)
 	int		i;
 	t_tnode	*node;
 
-	i = 0;
-
+	i = -1;
 	if (signal(SIGINT, sigint_handler_heredoc) == SIG_ERR)
 		return (ERROR);
-	while (cmd_list[i])
+	while (cmd_list[++i])
 	{
 		node = cmd_list[i];
 		while (node)
 		{
 			if (is_heredoc_node(node) && execute_heredoc(node) == ERROR)
-			{
-				perror("");
-				ft_putendl_fd("heredoc error", 2);
 				return (ERROR);
-			}
 			if (g_var.is_signal)
 			{
 				g_var.is_signal = 0;
@@ -59,7 +54,6 @@ t_error	execute_all_heredoc(t_tnode **cmd_list)
 			}
 			node = node->right;
 		}
-		i++;
 	}
 	if (signal(SIGINT, sigint_handler_prompt) == SIG_ERR)
 		return (ERROR);

--- a/execute/heredoc.c
+++ b/execute/heredoc.c
@@ -6,16 +6,20 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/11 18:40:41 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/13 15:14:04 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/16 18:40:52 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdlib.h>
 #include <stdbool.h>
+#include <signal.h>
 #include "ds_tree.h"
 #include "token.h"
 #include "libft.h"
 #include "execute.h"
+#include "minishell.h"
+
+extern t_global	g_var;
 
 static bool	is_heredoc_node(t_tnode *node)
 {
@@ -33,6 +37,9 @@ t_error	execute_all_heredoc(t_tnode **cmd_list)
 	t_tnode	*node;
 
 	i = 0;
+
+	if (signal(SIGINT, sigint_handler_heredoc) == SIG_ERR)
+		return (ERROR);
 	while (cmd_list[i])
 	{
 		node = cmd_list[i];
@@ -44,9 +51,17 @@ t_error	execute_all_heredoc(t_tnode **cmd_list)
 				ft_putendl_fd("heredoc error", 2);
 				return (ERROR);
 			}
+			if (g_var.is_signal)
+			{
+				g_var.is_signal = 0;
+				signal(SIGINT, sigint_handler_prompt);
+				return (FAIL);
+			}
 			node = node->right;
 		}
 		i++;
 	}
+	if (signal(SIGINT, sigint_handler_prompt) == SIG_ERR)
+		return (ERROR);
 	return (SCS);
 }

--- a/execute/heredoc_util.c
+++ b/execute/heredoc_util.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/11 20:42:06 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/13 15:10:08 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/16 18:43:26 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,6 +20,9 @@
 #include "libft.h"
 #include "execute.h"
 #include "return.h"
+#include "minishell.h"
+
+extern t_global	g_var;
 
 static char	*make_heredoc_filename(void)
 {
@@ -56,7 +59,7 @@ static void	heredoc_readline(int fd, char *delimiter)
 	while (1)
 	{
 		line = readline("> ");
-		if (!line || ft_strcmp(line, delimiter) == 0)
+		if (!line || ft_strcmp(line, delimiter) == 0 || g_var.is_signal)
 		{
 			free(line);
 			break ;
@@ -90,6 +93,8 @@ t_error	execute_heredoc(t_tnode *node)
 		return (ERROR);
 	heredoc_readline(fd, delimiter);
 	change_node_info(node, file_name);
+	if (g_var.is_signal)
+		unlink(file_name);
 	if (close(fd) == -1)
 		return (ERROR);
 	return (SCS);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/10 19:35:48 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/16 17:43:09 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/16 18:09:39 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,6 +26,7 @@ typedef struct s_global
 	struct termios	old_term;
 	struct termios	new_term;
 	int				status;
+	int				is_signal;
 }	t_global;
 
 // signal.c

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/10 19:35:48 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/16 18:09:39 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/16 18:35:22 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,6 +32,7 @@ typedef struct s_global
 // signal.c
 void	sigint_handler_prompt(int signo);
 void	sigint_handler_parent(int signo);
+void	sigint_handler_heredoc(int signo);
 
 // terminal.c
 t_error	init_minishell_setting(char **env);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/10 19:35:48 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/16 13:07:52 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/16 17:43:09 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,9 +28,14 @@ typedef struct s_global
 	int				status;
 }	t_global;
 
+// signal.c
 void	sigint_handler_prompt(int signo);
 void	sigint_handler_parent(int signo);
+
+// terminal.c
 t_error	init_minishell_setting(char **env);
+
+// parse.c
 t_tnode	*parse_line(char *str);
 
 #endif

--- a/signal.c
+++ b/signal.c
@@ -1,0 +1,38 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   signal.c                                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/01/16 17:40:34 by wonyang           #+#    #+#             */
+/*   Updated: 2023/01/16 17:42:18 by wonyang          ###   ########seoul.kr  */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <unistd.h>
+#include <signal.h>
+#include <stdio.h>
+#include <readline/readline.h>
+#include "minishell.h"
+
+extern t_global	g_var;
+
+void	sigint_handler_prompt(int signo)
+{
+	(void)signo;
+	g_var.status = 1;
+	ft_putchar_fd('\n', STDOUT_FILENO);
+	rl_on_new_line();
+	rl_replace_line("", 0);
+	rl_redisplay();
+}
+
+void	sigint_handler_parent(int signo)
+{
+	(void)signo;
+	g_var.status = 130;
+	ft_putchar_fd('\n', STDOUT_FILENO);
+	rl_on_new_line();
+	rl_replace_line("", 0);
+}

--- a/signal.c
+++ b/signal.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/16 17:40:34 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/16 17:42:18 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/16 18:46:22 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <readline/readline.h>
+#include <sys/ioctl.h>
 #include "minishell.h"
 
 extern t_global	g_var;
@@ -35,4 +36,14 @@ void	sigint_handler_parent(int signo)
 	ft_putchar_fd('\n', STDOUT_FILENO);
 	rl_on_new_line();
 	rl_replace_line("", 0);
+}
+
+void	sigint_handler_heredoc(int signo)
+{
+	(void)signo;
+	ioctl(STDIN_FILENO, TIOCSTI, "\n");
+	rl_on_new_line();
+	rl_replace_line("", 0);
+	g_var.is_signal = 1;
+	g_var.status = 1;
 }

--- a/terminal.c
+++ b/terminal.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/10 15:47:32 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/16 17:41:45 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/16 18:10:01 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -62,5 +62,6 @@ t_error	init_minishell_setting(char **env)
 		return (ERROR);
 	get_terminal_setting();
 	g_var.status = 0;
+	g_var.is_signal = 0;
 	return (SCS);
 }

--- a/terminal.c
+++ b/terminal.c
@@ -6,15 +6,12 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/10 15:47:32 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/16 15:47:36 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/16 17:41:45 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <unistd.h>
 #include <term.h>
-#include <signal.h>
-#include <stdio.h>
-#include <readline/readline.h>
 #include "libft.h"
 #include "minishell.h"
 
@@ -27,25 +24,6 @@ static void	get_terminal_setting(void)
 	g_var.new_term.c_lflag &= ~ECHOCTL;
 	g_var.new_term.c_cc[VQUIT] = 0;
 	tcsetattr(STDIN_FILENO, TCSANOW, &(g_var.new_term));
-}
-
-void	sigint_handler_prompt(int signo)
-{
-	(void)signo;
-	g_var.status = 1;
-	ft_putchar_fd('\n', STDOUT_FILENO);
-	rl_on_new_line();
-	rl_replace_line("", 0);
-	rl_redisplay();
-}
-
-void	sigint_handler_parent(int signo)
-{
-	(void)signo;
-	g_var.status = 130;
-	ft_putchar_fd('\n', STDOUT_FILENO);
-	rl_on_new_line();
-	rl_replace_line("", 0);
 }
 
 static t_error	set_envp_value(t_envp *envp)


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

heredoc 시그널 처리

## 🧑‍💻 PR 세부 내용

### 수정사항
- 시그널 핸들러 함수 분리
- 전역 구조체에 is_signal 변수 추가
    - heredoc을 받는 도중 시그널로 인한 종료인지, 구분자나 ctrl+d로 인한 종료인지 구분하기 위함

### 동작방식
- heredoc 입력 받기 전 시그널 핸들러를 `sigint_handler_heredoc`으로 변경
- heredoc 도중 SIGINT 시그널이 들어올 경우 readline 입력을 종료
- 시그널로 인한 종료면 현재 받고 있던 heredoc의 임시 파일을 unlink함
- 종료 상태코드를 1로 만들고 대화형모드로 복귀

### bash와의 차이점
- heredoc을 여러 개 받는 도중 시그널로 인해 종료될 시, 앞에 받은 임시파일은 삭제시키지 못함
    - 오직 받고 있던 임시파일만 삭제시키고, 나머지는 /tmp 폴더에 남음
- `cat << heredoc > res`에서 heredoc을 시그널로 종료시키는 경우
    - bash : res 파일이 생성됨
    - minishell : res 파일이 생성되지 않음

## 📸 스크린샷

<img width="437" alt="스크린샷 2023-01-16 오후 7 11 37" src="https://user-images.githubusercontent.com/43935708/212653218-6bded0a9-7791-4d41-9472-a2ec307e5664.png">
