### PR TITLE
implement : minishell 시작 시 tmp 디렉토리 생성 기능 추가

### DIFF
--- a/execute/heredoc_util.c
+++ b/execute/heredoc_util.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/11 20:42:06 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/16 18:43:26 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/16 19:47:16 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,7 +47,7 @@ static char	*make_heredoc_filename(void)
 		res[i] = ft_abs(res[i]) % 26 + 65;
 		i++;
 	}
-	path = ft_strjoin("/tmp/.", res);
+	path = ft_strjoin("./tmp/.", res);
 	free(res);
 	return (path);
 }

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/10 19:35:48 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/16 18:35:22 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/16 20:01:28 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,5 +39,8 @@ t_error	init_minishell_setting(char **env);
 
 // parse.c
 t_tnode	*parse_line(char *str);
+
+// main.c
+void	run_code(char *str);
 
 #endif

--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/08 22:30:32 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/16 13:10:07 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/16 19:42:32 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,6 +20,18 @@
 #include "token.h"
 
 t_global	g_var;
+
+void	run_code(char *str)
+{
+	t_tnode	*root;
+
+	root = parse_line(str);
+	if (!root)
+		return ;
+	add_history(str);
+	execute(root);
+	clear_node(root, del_t_token);
+}
 
 static void	routine(void)
 {

--- a/terminal.c
+++ b/terminal.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/10 15:47:32 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/16 18:10:01 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/16 19:53:03 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,5 +63,6 @@ t_error	init_minishell_setting(char **env)
 	get_terminal_setting();
 	g_var.status = 0;
 	g_var.is_signal = 0;
+	run_code("mkdir -p tmp");
 	return (SCS);
 }


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

minishell이 시작할 때 tmp 디렉토리를 생성하는 기능 추가

## 🧑‍💻 PR 세부 내용

### 추가사항
- 문자열로 쉘 명령어를 생성할 수 있는 함수 추가
- minishell 시작 시 `mkdir -p tmp` 명령어로 현재 디렉토리에 tmp 폴더 생성
- heredoc 임시 파일을 minishell 디렉토리 안 tmp 디렉토리에 생성

### 한계점
- `./minishell/minishell`과 같이 다른 위치에서 minishell을 실행하면 제대로 된 위치에 디렉토리가 생성되지 않음