### PR TITLE
fix : #84/잘못된 명령어를 제대로 구분하지 못하는 오류 수정

### DIFF
--- a/execute/builtin.c
+++ b/execute/builtin.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/13 18:36:41 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/16 18:59:16 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/17 11:01:45 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,7 +39,7 @@ bool	is_builtin_cmd(t_tnode *node)
 	i = 0;
 	while (i < 7)
 	{
-		if (ft_strncmp(token->str, (char *)(cmd[i]), ft_strlen(cmd[i])) == 0)
+		if (ft_strcmp(token->str, (char *)(cmd[i])) == 0)
 			return (true);
 		i++;
 	}


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

잘못된 명령어를 제대로 구분하지 못하는 오류 수정

## 🧑‍💻 PR 세부 내용

- 명령어를 빌트인 명령어인지 비교하는 과정에서 strncmp 함수로 비교하고 있었음
- 빌트인 명령어로 시작하는 잘못된 명령에서 제대로 판별하지 못함
- strcmp 함수로 수정

## 📸 스크린샷
<img width="304" alt="스크린샷 2023-01-17 오전 11 02 04" src="https://user-images.githubusercontent.com/43935708/212793849-1b5d98e9-685c-496c-bc5a-2734af3d6305.png">

