### PR TITLE
Bug : 기타 오류 수정

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+         #
+#    By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/09/28 21:52:18 by wonyang           #+#    #+#              #
-#    Updated: 2023/01/16 20:59:55 by jeongmin         ###   ########.fr        #
+#    Updated: 2023/01/17 11:59:06 by wonyang          ###   ########seoul.kr   #
 #                                                                              #
 # **************************************************************************** #
 
@@ -24,7 +24,7 @@ HEADERS		= -I$(LIBFT) \
 LIBS		= -lft -L$(LIBFT) \
 			  -L$(RDLINE_DIR)/lib/ -lreadline
 
-CFLAGS		= -Wall -Werror -Wextra -g3 -fsanitize=address
+CFLAGS		= -Wall -Werror -Wextra
 
 # builtin source files
 BTN_DIR		= builtin/

--- a/execute/child.c
+++ b/execute/child.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/11 23:33:05 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/17 11:54:17 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/17 11:57:10 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -105,10 +105,9 @@ static pid_t	last_fork_child(t_tnode *cmd_node, int before_fd)
 	{
 		if (before_fd != STDIN_FILENO
 			&& ft_dup2(before_fd, STDIN_FILENO) == ERROR)
-			return (0);
+			exit(1);
 		if (child_execute(cmd_node) == ERROR)
-			return (0);
-		exit(1);
+			exit(1);
 	}
 	if (before_fd != STDIN_FILENO && close(before_fd) == -1)
 		return (0);

--- a/execute/child.c
+++ b/execute/child.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/11 23:33:05 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/16 21:18:36 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/17 11:54:17 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -108,6 +108,7 @@ static pid_t	last_fork_child(t_tnode *cmd_node, int before_fd)
 			return (0);
 		if (child_execute(cmd_node) == ERROR)
 			return (0);
+		exit(1);
 	}
 	if (before_fd != STDIN_FILENO && close(before_fd) == -1)
 		return (0);

--- a/execute/execute.c
+++ b/execute/execute.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/11 22:30:55 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/16 19:14:20 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/17 11:35:36 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,8 +42,8 @@ static int	wait_proc(pid_t *pid_list)
 	while (pid_list[i])
 	{
 		waitpid(pid_list[i], &status, 0);
-		if (status == 2)
-			status = 130 * 256;
+		if (0 < status && status < 256)
+			status = (128 + status) * 256;
 		i++;
 	}
 	return (status / 256);

--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/08 22:30:32 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/17 11:15:19 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/17 11:59:07 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,7 +57,6 @@ static void	routine(void)
 		execute(root);
 		clear_node(root, del_t_token);
 		free(str);
-		system("leaks minishell | grep leaked");
 	}
 }
 

--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/08 22:30:32 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/16 19:42:32 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/17 11:15:19 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,6 @@ void	run_code(char *str)
 	root = parse_line(str);
 	if (!root)
 		return ;
-	add_history(str);
 	execute(root);
 	clear_node(root, del_t_token);
 }
@@ -58,6 +57,7 @@ static void	routine(void)
 		execute(root);
 		clear_node(root, del_t_token);
 		free(str);
+		system("leaks minishell | grep leaked");
 	}
 }
 

--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@
 /*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/08 22:30:32 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/17 11:59:07 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/17 12:31:48 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,10 +50,10 @@ static void	routine(void)
 			free(str);
 			continue ;
 		}
+		add_history(str);
 		root = parse_line(str);
 		if (!root)
 			continue ;
-		add_history(str);
 		execute(root);
 		clear_node(root, del_t_token);
 		free(str);


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

테스트케이스 체크 중 나온 오류 수정

## 🧑‍💻 PR 세부 내용

- 초기화 과정에서 임시 폴더를 만들 때, 해당 명령어가 history에 남아있는 오류 수정
- 자식프로세스를 SIGQUIT 시그널로 종료시킬 때 종료 상태코드를 131번으로 설정하도록 수정
- 명령어가 한개만 들어오고, 리다이렉션이 올바르지 않을 때, 자식 프로세스가 제대로 종료되지 않는 현상 수정
    - last_fork_child 함수에도 오류 발생 시 exit(1)로 종료하도록 바꿈
- main 브랜치에 있는 디버깅용 코드 삭제