### PR TITLE
Bug: #88/명령어가 들어오지 않을 때 syntax error로 처리

### DIFF
--- a/builtin/cd.c
+++ b/builtin/cd.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   cd.c                                               :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
+/*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/06 21:36:28 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/14 11:57:01 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/17 13:37:20 by jeongmin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,7 +48,7 @@ static t_error	update_pwd(t_envp *envp)
 
 static t_error	path_error(char *path)
 {
-	ft_putstr_fd("bash: cd: ", STDERR_FILENO);
+	ft_putstr_fd("minishell: cd: ", STDERR_FILENO);
 	ft_putstr_fd(path, STDERR_FILENO);
 	if (access(path, F_OK) != 0)
 		ft_putendl_fd(": No such file or directory", STDERR_FILENO);
@@ -68,7 +68,7 @@ static t_error	move_home(t_envp *envp)
 	path = search_key_value(envp, "HOME");
 	if (!path)
 	{
-		ft_putendl_fd("bash: cd: HOME not set", STDERR_FILENO);
+		ft_putendl_fd("minishell: cd: HOME not set", STDERR_FILENO);
 		return (FAIL);
 	}
 	if (chdir(path) != 0)
@@ -83,7 +83,7 @@ static t_error	move_oldpwd(t_envp *envp)
 	path = search_key_value(envp, "OLDPWD");
 	if (!path)
 	{
-		ft_putendl_fd("bash: cd: OLDPWD not set", STDERR_FILENO);
+		ft_putendl_fd("minishell: cd: OLDPWD not set", STDERR_FILENO);
 		return (FAIL);
 	}
 	if (chdir(path) != 0)

--- a/builtin/exit.c
+++ b/builtin/exit.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exit.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
+/*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/09 16:15:07 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/15 19:48:05 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/17 13:37:19 by jeongmin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,14 +47,14 @@ int	ft_exit(char **argv, int child)
 		ft_putendl_fd("exit", STDERR_FILENO);
 	if (is_valid_argument(argv[1]) == false)
 	{
-		ft_putstr_fd("bash: exit: ", STDERR_FILENO);
+		ft_putstr_fd("minishell: exit: ", STDERR_FILENO);
 		ft_putstr_fd(argv[1], STDERR_FILENO);
 		ft_putendl_fd(": numeric argument required", STDERR_FILENO);
 		exit(255);
 	}
 	if (count_argument(argv) > 2)
 	{
-		ft_putendl_fd("bash: exit: too many arguments", STDERR_FILENO);
+		ft_putendl_fd("minishell: exit: too many arguments", STDERR_FILENO);
 		return (1);
 	}
 	tcsetattr(STDIN_FILENO, TCSANOW, &(g_var.old_term));

--- a/builtin/export.c
+++ b/builtin/export.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   export.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
+/*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/09 16:46:45 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/14 18:28:52 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/17 13:37:19 by jeongmin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,7 @@ static bool	is_valid_key(char *key)
 		|| ft_strchr(key, '\'')
 		|| ft_strchr(key, ' '))
 	{
-		ft_putstr_fd("bash: export: `", STDERR_FILENO);
+		ft_putstr_fd("minishell: export: `", STDERR_FILENO);
 		ft_putstr_fd(key, STDERR_FILENO);
 		ft_putendl_fd("': not a valid identifier", STDERR_FILENO);
 		return (false);

--- a/execute/child.c
+++ b/execute/child.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   child.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
+/*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/11 23:33:05 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/17 11:57:10 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/01/17 13:37:19 by jeongmin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,7 @@ static void	child_execve(t_tnode *node, char *path, char **argv)
 
 	if (is_builtin_cmd(node) == false && !path)
 	{
-		ft_putstr_fd("bash: ", STDERR_FILENO);
+		ft_putstr_fd("minishell: ", STDERR_FILENO);
 		ft_putstr_fd(argv[0], STDERR_FILENO);
 		if (ft_strcmp(argv[0], "") != 0 && is_directory(argv[0]))
 		{

--- a/parse.c
+++ b/parse.c
@@ -6,7 +6,7 @@
 /*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/15 17:20:31 by wonyang           #+#    #+#             */
-/*   Updated: 2023/01/16 23:45:52 by jeongmin         ###   ########.fr       */
+/*   Updated: 2023/01/17 13:40:35 by jeongmin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,6 +41,11 @@ static t_list	*pre_processing(char *str)
 	lst = tokenization(str);
 	if (!lst)
 		return (NULL);
+	if (lst->next == NULL)
+	{
+		ft_lstclear(&lst, &del_t_token);
+		return (NULL);
+	}
 	if (!is_correct_syntax(lst->next))
 	{
 		ft_lstclear(&lst, &del_t_token);

--- a/parsing/check_syntax.c
+++ b/parsing/check_syntax.c
@@ -6,7 +6,7 @@
 /*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/12 21:52:16 by jeongmin          #+#    #+#             */
-/*   Updated: 2023/01/15 15:43:34 by jeongmin         ###   ########.fr       */
+/*   Updated: 2023/01/17 13:38:17 by jeongmin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,7 @@ static bool	is_correct_paren(t_list *lst, char **str)
 	int	cnt;
 
 	cnt = 0;
-	*str = "`invalid parenthesis pair'";
+	*str = "invalid parenthesis pair";
 	while (lst)
 	{
 		cnt += check_paren(lst->content);
@@ -32,7 +32,7 @@ static bool	is_correct_paren(t_list *lst, char **str)
 
 static bool	is_correct_io(t_list *lst, char **str)
 {
-	*str = "`redirection file does not exist'";
+	*str = "redirection file does not exist";
 	while (lst)
 	{
 		if (is_this_symbol(lst->content, T_IO))
@@ -71,12 +71,12 @@ static bool	is_paren_pos_ok(t_list *lst)
 	return (true);
 }
 
-static bool	is_dsv_pos_ok(t_list *lst, char	**str)
+static bool	is_cmd_pos_ok(t_list *lst, char	**str)
 {
 	int	flag;
 
 	flag = 0;
-	*str = NULL;
+	*str = "command not found";
 	while (lst)
 	{
 		if (is_dsv_symbol(lst->content))
@@ -92,7 +92,7 @@ static bool	is_dsv_pos_ok(t_list *lst, char	**str)
 			lst = lst->next;
 		lst = lst->next;
 	}
-	if (flag != 1 && *str)
+	if (flag != 1)
 		return (false);
 	return (true);
 }
@@ -104,20 +104,20 @@ bool	is_correct_syntax(t_list *lst)
 	str = NULL;
 	if (!is_correct_paren(lst, &str) || !is_correct_io(lst, &str))
 	{
-		ft_putstr_fd("bash: syntax error ", 2);
+		ft_putstr_fd("minishell: syntax error ", 2);
 		ft_putendl_fd(str, 2);
 		return (false);
 	}
 	if (!is_paren_pos_ok(lst))
 	{
-		ft_putendl_fd("bash: syntax error `invalid parenthesis position'", 2);
+		ft_putstr_fd("minishell: syntax error: ", 2);
+		ft_putendl_fd("invalid parenthesis position", 2);
 		return (false);
 	}
-	if (!is_dsv_pos_ok(lst, &str))
+	if (!is_cmd_pos_ok(lst, &str) && str)
 	{
-		ft_putstr_fd("bash: syntax error near unexpected token `", 2);
-		ft_putstr_fd(str, 2);
-		ft_putendl_fd("'", 2);
+		ft_putstr_fd("minishell: syntax error: ", 2);
+		ft_putendl_fd(str, 2);
 		return (false);
 	}
 	return (true);


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

명령어가 들어오지 않을 때 syntax error로 처리

## 🧑‍💻 PR 세부 내용

- cmd가 space로만 들어올 때 `pre_processing` 과정에서 중간에 종료
- 명령어가 들어오지 않을 때 `syntax error: command not found` 처리
- error msg 안의 `bash`를 `minishell`로 변경

## 📸 스크린샷

<img width="396" alt="스크린샷 2023-01-17 오후 1 53 18" src="https://user-images.githubusercontent.com/44529556/212812966-58500875-df66-4854-a2c5-496316f67e38.png">
